### PR TITLE
Update Audi A3: fix generation years and add references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Audi A3
 
+This repository contains signal set configurations for the Audi A3, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Audi A3.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_A3"
+
 generations:
   - name: "First Generation (8L)"
     start_year: 1996
@@ -5,8 +8,8 @@ generations:
     description: "The original Audi A3 pioneered the premium compact segment, built on the Volkswagen Group A platform. Initially available only as a three-door hatchback, it featured a range of four-cylinder engines including the 1.8T. The first-generation A3 established Audi's reputation for bringing premium quality and features to smaller vehicles."
 
   - name: "Second Generation (8P)"
-    start_year: 2003
-    end_year: 2012
+    start_year: 2004
+    end_year: 2013
     description: "Built on the Volkswagen Group A5 (PQ35) platform, the second-generation A3 expanded to include a five-door Sportback variant. Engine options ranged from 1.2L to 3.2L V6 petrol and various TDI diesel units. This generation introduced the S3 and RS3 high-performance variants and received a facelift in 2008 with updated styling and technology."
 
   - name: "Third Generation (8V)"
@@ -15,6 +18,6 @@ generations:
     description: "Based on the Volkswagen Group MQB platform, the third-generation A3 was offered in three-door hatchback, five-door Sportback, four-door sedan, and cabriolet body styles. It featured Audi's latest technology including the Virtual Cockpit digital instrument cluster and advanced driver assistance systems. Engine options included efficient TFSI petrol and TDI diesel units, plus the e-tron plug-in hybrid variant. The high-performance S3 and RS3 models continued, with the latter featuring a distinctive five-cylinder engine."
 
   - name: "Fourth Generation (8Y)"
-    start_year: 2020
+    start_year: 2022
     end_year: null
     description: "The current A3 continues on the MQB platform but with significant updates, offered as a five-door Sportback and four-door sedan. It features a more angular design language and a completely redesigned interior with dual digital screens and connected services. Powertrain options include mild-hybrid technology, and the range continues to include S3 and RS3 performance variants. This generation focuses on digitalization, connectivity, and electrification while maintaining Audi's premium positioning in the compact segment."


### PR DESCRIPTION
- Fixed: Second generation start year 2003→2004, end year 2012→2013 per Wikipedia model_years
- Fixed: Fourth generation start year 2020→2022 per Wikipedia model_years
- Added: Wikipedia reference to generations.yaml
- Updated: README.md with standard template

Per Wikipedia: Gen 2 model years 2004-2013, Gen 4 model years 2022-present (production started May 2020 but 2020 was not a model year).

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
